### PR TITLE
feat: add flexsim v5 static project skeleton

### DIFF
--- a/flexsim_v5/core/app.js
+++ b/flexsim_v5/core/app.js
@@ -1,0 +1,51 @@
+import { placeholderSvg } from './util.js';
+import { renderHome } from '../features/home.js';
+import { renderCreator } from '../features/creator.js';
+import { renderStats } from '../features/stats.js';
+import { renderSettings } from '../features/settings.js';
+import { renderInventory } from '../features/inventory.js';
+import { renderGarage } from '../features/garage.js';
+import { renderShopGenerale } from '../features/shop_generale.js';
+import { renderShopMeccanico } from '../features/shop_meccanico.js';
+import { renderShopLoschi } from '../features/shop_loschi.js';
+import { renderJobs } from '../features/jobs.js';
+import { renderStudy } from '../features/study.js';
+
+const features = {
+  home: renderHome,
+  creator: renderCreator,
+  stats: renderStats,
+  settings: renderSettings,
+  inventory: renderInventory,
+  garage: renderGarage,
+  shop_generale: renderShopGenerale,
+  shop_meccanico: renderShopMeccanico,
+  shop_loschi: renderShopLoschi,
+  jobs: renderJobs,
+  study: renderStudy
+};
+
+export function initApp() {
+  const appEl = document.getElementById('app');
+
+  function loadFeature(name) {
+    appEl.innerHTML = '';
+    const view = features[name];
+    const node = view ? view() : document.createTextNode('Feature mancante');
+    if (node instanceof HTMLElement) {
+      appEl.appendChild(node);
+    } else {
+      const div = document.createElement('div');
+      div.className = 'card';
+      div.appendChild(node);
+      appEl.appendChild(div);
+    }
+  }
+
+  document.querySelectorAll('.tabs button').forEach(btn => {
+    btn.addEventListener('click', () => loadFeature(btn.dataset.feature));
+  });
+
+  // default
+  loadFeature('home');
+}

--- a/flexsim_v5/core/store.js
+++ b/flexsim_v5/core/store.js
@@ -1,0 +1,9 @@
+const state = {};
+
+export function getState(key) {
+  return key ? state[key] : { ...state };
+}
+
+export function setState(key, value) {
+  state[key] = value;
+}

--- a/flexsim_v5/core/util.js
+++ b/flexsim_v5/core/util.js
@@ -1,0 +1,11 @@
+export const placeholderSvg =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(`<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100"><rect width="100" height="100" fill="#333"/><text x="50" y="55" font-size="12" fill="#eee" text-anchor="middle">N/A</text></svg>`);
+
+export function attachImgFallback(img) {
+  if (img && img.tagName === 'IMG') {
+    img.addEventListener('error', () => {
+      img.src = placeholderSvg;
+    }, { once: true });
+  }
+}

--- a/flexsim_v5/data/avatars.json
+++ b/flexsim_v5/data/avatars.json
@@ -1,0 +1,3 @@
+[
+  { "id": 1, "name": "Base", "img": "img/avatar1.png" }
+]

--- a/flexsim_v5/data/jobs.json
+++ b/flexsim_v5/data/jobs.json
@@ -1,0 +1,4 @@
+[
+  { "name": "Programmatore", "pay": 1000 },
+  { "name": "Designer", "pay": 800 }
+]

--- a/flexsim_v5/data/loschi_jobs.json
+++ b/flexsim_v5/data/loschi_jobs.json
@@ -1,0 +1,3 @@
+[
+  { "name": "Contrabbandiere", "pay": 1500 }
+]

--- a/flexsim_v5/data/shops_generale.json
+++ b/flexsim_v5/data/shops_generale.json
@@ -1,0 +1,3 @@
+[
+  { "name": "Corda", "price": 20 }
+]

--- a/flexsim_v5/data/shops_loschi.json
+++ b/flexsim_v5/data/shops_loschi.json
@@ -1,0 +1,3 @@
+[
+  { "name": "Documento falso", "price": 500 }
+]

--- a/flexsim_v5/data/shops_meccanico.json
+++ b/flexsim_v5/data/shops_meccanico.json
@@ -1,0 +1,3 @@
+[
+  { "name": "Chiave inglese", "price": 50 }
+]

--- a/flexsim_v5/data/study.json
+++ b/flexsim_v5/data/study.json
@@ -1,0 +1,4 @@
+[
+  { "name": "Informatica", "cost": 500 },
+  { "name": "Design", "cost": 400 }
+]

--- a/flexsim_v5/features/_shopCommon.js
+++ b/flexsim_v5/features/_shopCommon.js
@@ -1,0 +1,6 @@
+export function renderShop(title) {
+  const div = document.createElement('div');
+  div.className = 'card';
+  div.textContent = `Shop: ${title}`;
+  return div;
+}

--- a/flexsim_v5/features/creator.js
+++ b/flexsim_v5/features/creator.js
@@ -1,0 +1,6 @@
+export function renderCreator() {
+  const div = document.createElement('div');
+  div.className = 'card';
+  div.textContent = 'Sezione Creator';
+  return div;
+}

--- a/flexsim_v5/features/garage.js
+++ b/flexsim_v5/features/garage.js
@@ -1,0 +1,6 @@
+export function renderGarage() {
+  const div = document.createElement('div');
+  div.className = 'card';
+  div.textContent = 'Garage veicoli';
+  return div;
+}

--- a/flexsim_v5/features/home.js
+++ b/flexsim_v5/features/home.js
@@ -1,0 +1,6 @@
+export function renderHome() {
+  const div = document.createElement('div');
+  div.className = 'card';
+  div.textContent = 'Benvenuto in FlexSim v5';
+  return div;
+}

--- a/flexsim_v5/features/inventory.js
+++ b/flexsim_v5/features/inventory.js
@@ -1,0 +1,6 @@
+export function renderInventory() {
+  const div = document.createElement('div');
+  div.className = 'card';
+  div.textContent = 'Inventario';
+  return div;
+}

--- a/flexsim_v5/features/jobs.js
+++ b/flexsim_v5/features/jobs.js
@@ -1,0 +1,18 @@
+export function renderJobs() {
+  const div = document.createElement('div');
+  div.className = 'card';
+  div.textContent = 'Lavori disponibili';
+  fetch('./data/jobs.json')
+    .then(r => r.json())
+    .then(data => {
+      const ul = document.createElement('ul');
+      data.forEach(j => {
+        const li = document.createElement('li');
+        li.textContent = j.name;
+        ul.appendChild(li);
+      });
+      div.appendChild(ul);
+    })
+    .catch(() => {});
+  return div;
+}

--- a/flexsim_v5/features/settings.js
+++ b/flexsim_v5/features/settings.js
@@ -1,0 +1,6 @@
+export function renderSettings() {
+  const div = document.createElement('div');
+  div.className = 'card';
+  div.textContent = 'Impostazioni';
+  return div;
+}

--- a/flexsim_v5/features/shop_generale.js
+++ b/flexsim_v5/features/shop_generale.js
@@ -1,0 +1,5 @@
+import { renderShop } from './_shopCommon.js';
+
+export function renderShopGenerale() {
+  return renderShop('Generale');
+}

--- a/flexsim_v5/features/shop_loschi.js
+++ b/flexsim_v5/features/shop_loschi.js
@@ -1,0 +1,5 @@
+import { renderShop } from './_shopCommon.js';
+
+export function renderShopLoschi() {
+  return renderShop('Loschi');
+}

--- a/flexsim_v5/features/shop_meccanico.js
+++ b/flexsim_v5/features/shop_meccanico.js
@@ -1,0 +1,5 @@
+import { renderShop } from './_shopCommon.js';
+
+export function renderShopMeccanico() {
+  return renderShop('Meccanico');
+}

--- a/flexsim_v5/features/stats.js
+++ b/flexsim_v5/features/stats.js
@@ -1,0 +1,6 @@
+export function renderStats() {
+  const div = document.createElement('div');
+  div.className = 'card';
+  div.textContent = 'Statistiche generali';
+  return div;
+}

--- a/flexsim_v5/features/study.js
+++ b/flexsim_v5/features/study.js
@@ -1,0 +1,18 @@
+export function renderStudy() {
+  const div = document.createElement('div');
+  div.className = 'card';
+  div.textContent = 'Corsi di studio';
+  fetch('./data/study.json')
+    .then(r => r.json())
+    .then(data => {
+      const ul = document.createElement('ul');
+      data.forEach(j => {
+        const li = document.createElement('li');
+        li.textContent = j.name;
+        ul.appendChild(li);
+      });
+      div.appendChild(ul);
+    })
+    .catch(() => {});
+  return div;
+}

--- a/flexsim_v5/index.html
+++ b/flexsim_v5/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FlexSim v5</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <nav class="tabs">
+    <button data-feature="home">Home</button>
+    <button data-feature="creator">Creator</button>
+    <button data-feature="stats">Stats</button>
+    <button data-feature="settings">Settings</button>
+  </nav>
+  <main id="app" class="cards"></main>
+  <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/flexsim_v5/main.js
+++ b/flexsim_v5/main.js
@@ -1,0 +1,3 @@
+import { initApp } from './core/app.js';
+
+initApp();

--- a/flexsim_v5/netlify.toml
+++ b/flexsim_v5/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  publish = "flexsim_v5"

--- a/flexsim_v5/style.css
+++ b/flexsim_v5/style.css
@@ -1,0 +1,42 @@
+:root {
+  color-scheme: dark;
+  --bg: #121212;
+  --fg: #eee;
+  --accent: #1e88e5;
+  font-family: sans-serif;
+}
+
+body {
+  background: var(--bg);
+  color: var(--fg);
+  margin: 0;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background: #1e1e1e;
+  border-bottom: 1px solid #333;
+}
+
+.tabs button {
+  background: none;
+  color: var(--fg);
+  border: 1px solid #333;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.cards {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.card {
+  background: #1e1e1e;
+  border: 1px solid #333;
+  padding: 1rem;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- scaffold flexsim v5 static site with dark card UI
- add core modules, feature stubs, and sample data JSON
- configure Netlify for static deployment

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3541f2e08320a9139d0f24ee19f2